### PR TITLE
Empty test cases

### DIFF
--- a/src/Html/Parser.elm
+++ b/src/Html/Parser.elm
@@ -20,8 +20,12 @@ import Parser exposing ((|.), (|=), Parser)
 
 -}
 run : String -> Result (List Parser.DeadEnd) (List Node)
-run =
-    Parser.run (oneOrMore "node" node)
+run str =
+    if String.isEmpty str then
+        Ok []
+
+    else
+        Parser.run (oneOrMore "node" node) str
 
 
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -35,7 +35,9 @@ testError s =
 textNodeTests : Test
 textNodeTests =
     describe "TextNode"
-        [ test "basic1" (testParse "1" (Text "1"))
+        [ test "empty" (testParseAll "" [])
+        , test "space" (testParse " " (Text " "))
+        , test "basic1" (testParse "1" (Text "1"))
         , test "basic2" (testParse "a" (Text "a"))
         , test "basic3" (testParse "1a" (Text "1a"))
         , test "basic4" (testParse "^" (Text "^"))


### PR DESCRIPTION
Since a plain string, non-empty doesn't fail and an empty string is a plain string, then it should not return `Err`. 

Closes https://github.com/hecrj/html-parser/issues/4