### PR TITLE
Fix decimal entities failing to parse if they contain leading zeros

### DIFF
--- a/src/Html/Parser.elm
+++ b/src/Html/Parser.elm
@@ -182,7 +182,9 @@ numericCharacterReference =
                 [ Parser.succeed identity
                     |. Parser.chompIf (\c -> c == 'x' || c == 'X')
                     |= hexadecimal
-                , Parser.int
+                , Parser.succeed identity
+                    |. Parser.chompWhile ((==) '0')
+                    |= Parser.int
                 ]
     in
     Parser.succeed identity

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -55,6 +55,7 @@ textNodeTests =
         , test "decodeD" (testParse "a&nbsp;b" (Text "a\u{00A0}b"))
         , test "decodeE" (testParse "a&nbsp;&nbsp;b" (Text "a\u{00A0}\u{00A0}b"))
         , test "decodeF" (testParse """<img alt="&lt;">""" (Element "img" [ ( "alt", "<" ) ] []))
+        , test "decodeG" (testParse "&#0038;" (Text "&"))
         ]
 
 


### PR DESCRIPTION
Entities like `&#039;` would not be picked up by the parser and just show as plain text. This should be fixed now!

The following has been done in addition to the fix:
- [x] Test case added for leading zero decimal entities
- [x] Verified that `elm-test` produced no errors