### PR TITLE
Add HTML document support and tests.

### DIFF
--- a/src/Html/Parser.elm
+++ b/src/Html/Parser.elm
@@ -1,7 +1,7 @@
 module Html.Parser exposing
-    ( run, Node(..), Document, Attribute
+    ( run, Node(..), Attribute
     , node, nodeToString
-    , documentToString, runDocument
+    , Document, documentToString, runDocument
     )
 
 {-| Parse HTML 5 in Elm.


### PR DESCRIPTION
Targeted at solving #12 in a basic, legacy-supporting way. Adds `Document` type, `document` parser, `runDocument` parsing command, and `documentToString` un-parsing command. It also splits up the `nodeToString` parsing function into more general pieces, which are re-used in `documentToString`.

I also made a slight change to the comment-to-string conversion because it was adding spaces to the HTML comments if I parsed a document then to-stringed it then parsed the string again. Now it doesn't do that and, as far as I can tell, still matches the [HTML living standard](https://html.spec.whatwg.org/).

Fixes #12.