### PR TITLE
Set video "muted" attribute as property in Parser.Util.toVirtualDom

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/parser": "1.0.0 <= v < 2.0.0",
         "elm/virtual-dom": "1.0.2 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0"

--- a/src/Html/Parser/Util.elm
+++ b/src/Html/Parser/Util.elm
@@ -9,10 +9,9 @@ module Html.Parser.Util exposing (toVirtualDom)
 
 -}
 
-import Html exposing (..)
-import Html.Attributes exposing (..)
+import Html exposing (Attribute, Html, text)
+import Html.Attributes exposing (attribute)
 import Html.Parser exposing (Node(..))
-import VirtualDom
 
 
 {-| Converts nodes to virtual dom nodes.

--- a/src/Html/Parser/Util.elm
+++ b/src/Html/Parser/Util.elm
@@ -10,8 +10,9 @@ module Html.Parser.Util exposing (toVirtualDom)
 -}
 
 import Html exposing (Attribute, Html, text)
-import Html.Attributes exposing (attribute)
+import Html.Attributes exposing (attribute, property)
 import Html.Parser exposing (Node(..))
+import Json.Encode as Encode
 
 
 {-| Converts nodes to virtual dom nodes.
@@ -25,7 +26,18 @@ toVirtualDomEach : Node -> Html msg
 toVirtualDomEach node =
     case node of
         Element name attrs children ->
-            Html.node name (List.map toAttribute attrs) (toVirtualDom children)
+            Html.node name
+                (List.map
+                    (case name of
+                        "video" ->
+                            toVideoAttribute
+
+                        _ ->
+                            toAttribute
+                    )
+                    attrs
+                )
+                (toVirtualDom children)
 
         Text s ->
             text s
@@ -37,3 +49,28 @@ toVirtualDomEach node =
 toAttribute : ( String, String ) -> Attribute msg
 toAttribute ( name, value ) =
     attribute name value
+
+
+toVideoAttribute : ( String, String ) -> Attribute msg
+toVideoAttribute ( name, value ) =
+    case name of
+        "muted" ->
+            stringToBool value
+                |> Encode.bool
+                |> property name
+
+        _ ->
+            attribute name value
+
+
+stringToBool : String -> Bool
+stringToBool str =
+    case (String.trim >> String.toLower) str of
+        "false" ->
+            False
+
+        "no" ->
+            False
+
+        _ ->
+            True


### PR DESCRIPTION
This is a small change to allow parsed `<video>` elements to play in Chrome with the bundled `toVirtualDom` utility.

Chrome needs to set the `muted` attribute on `<video>` elements as a property in order for autoplay to work (See [this thread](https://discourse.elm-lang.org/t/how-to-set-the-muted-attribute-of-a-video/5794) on Elm Discourse). Note that this is only a Chrome requirement; videos will autoplay in Firefox and Safari with the current implementation.

So in short, this PR will allow the following to autoplay with `Utils.toVirtualDom`:

```
<video autoplay muted loop>
    <source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
</video>
```

I was careful to apply this change only to video elements. I know the code looks a bit funky; totally open if you prefer a different style of implementation.